### PR TITLE
Makefile.split: fix indentation to use tab instead of spaces

### DIFF
--- a/Makefile.split
+++ b/Makefile.split
@@ -1,16 +1,16 @@
 # Makefile for when everything is split up nicely.
 
 install: libMali.so libEGL.so.1.4 libGLESv1_CM.so.1.1 libGLESv2.so.2.0
-        $(INSTALL_DATA) $^ $(libdir)
+	$(INSTALL_DATA) $^ $(libdir)
 
-        $(RM) $(libdir)libEGL.so.1 $(libdir)libEGL.so
-        $(LN) libEGL.so.1.4 $(libdir)libEGL.so.1
-        $(LN) libEGL.so.1 $(libdir)libEGL.so
+	$(RM) $(libdir)libEGL.so.1 $(libdir)libEGL.so
+	$(LN) libEGL.so.1.4 $(libdir)libEGL.so.1
+	$(LN) libEGL.so.1 $(libdir)libEGL.so
 
-        $(RM) $(libdir)libGLESv1_CM.so.1 $(libdir)libGLESv1_CM.so
-        $(LN) libGLESv1_CM.so.1.1 $(libdir)libGLESv1_CM.so.1
-        $(LN) libGLESv1_CM.so.1 $(libdir)libGLESv1_CM.so
+	$(RM) $(libdir)libGLESv1_CM.so.1 $(libdir)libGLESv1_CM.so
+	$(LN) libGLESv1_CM.so.1.1 $(libdir)libGLESv1_CM.so.1
+	$(LN) libGLESv1_CM.so.1 $(libdir)libGLESv1_CM.so
 
-        $(RM) $(libdir)libGLESv2.so.2 $(libdir)libGLESv2.so
-        $(LN) libGLESv2.so.2.0 $(libdir)libGLESv2.so.2
-        $(LN) libGLESv2.so.2 $(libdir)libGLESv2.so
+	$(RM) $(libdir)libGLESv2.so.2 $(libdir)libGLESv2.so
+	$(LN) libGLESv2.so.2.0 $(libdir)libGLESv2.so.2
+	$(LN) libGLESv2.so.2 $(libdir)libGLESv2.so


### PR DESCRIPTION
Resolves the following make error building r3p2-01rel1 release:
../../../Makefile.split:4: **\* missing separator (did you mean TAB instead of 8 spaces?).  Stop.

Signed-off-by: Jonathan Liu net147@gmail.com
